### PR TITLE
Update nav style for white text and ribbon

### DIFF
--- a/app-development.html
+++ b/app-development.html
@@ -21,9 +21,10 @@
             z-index: -1;
         }
         h1.title {
-            color: blue;
+            color: white;
             text-align: center;
             text-decoration: underline;
+            font-size: 48px;
         }
         #controls {
             text-align: center;
@@ -44,11 +45,17 @@
         nav {
             text-align: center;
             margin-top: 10px;
+            background: rgba(0,0,0,0.6);
+            padding: 10px 0;
         }
         nav a {
             margin: 0 15px;
-            color: blue;
-            text-decoration: underline;
+            color: white;
+            text-decoration: none;
+            border: 1px solid white;
+            padding: 8px 15px;
+            border-radius: 4px;
+            background: rgba(0,0,0,0.6);
         }
         #appContainer {
             background: rgba(0,0,0,0.6);
@@ -74,7 +81,7 @@
 <body>
     <h1 class="title">Lennon Mueller</h1>
     <nav>
-        <a href="index.html">Home</a> |
+        <a href="index.html">Home</a>
         <a href="app-development.html">App Development</a>
     </nav>
 <div id="appContainer">

--- a/index.html
+++ b/index.html
@@ -21,18 +21,25 @@
             z-index: -1;
         }
         h1.title {
-            color: blue;
+            color: white;
             text-align: center;
             text-decoration: underline;
+            font-size: 48px;
         }
         nav {
             text-align: center;
             margin-top: 10px;
+            background: rgba(0,0,0,0.6);
+            padding: 10px 0;
         }
         nav a {
             margin: 0 15px;
-            color: blue;
-            text-decoration: underline;
+            color: white;
+            text-decoration: none;
+            border: 1px solid white;
+            padding: 8px 15px;
+            border-radius: 4px;
+            background: rgba(0,0,0,0.6);
         }
         #homeContainer {
             background: rgba(0,0,0,0.6);
@@ -49,7 +56,7 @@
 <body>
     <h1 class="title">Lennon Mueller</h1>
     <nav>
-        <a href="index.html">Home</a> |
+        <a href="index.html">Home</a>
         <a href="app-development.html">App Development</a>
     </nav>
     <div id="homeContainer">


### PR DESCRIPTION
## Summary
- restyle the Home and App Dev buttons with a semi-transparent background
- enlarge the page titles
- switch nav text to white and remove the old pipe separator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685424fd4234832b8a2d6a2f54646e45