### PR TITLE
Add AI/ML demo with churn model skeleton

### DIFF
--- a/ai-ml.html
+++ b/ai-ml.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lennon Mueller Portfolio - AI/ML</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+        }
+        body::before {
+            content: "";
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: url('Mueller Logo.png') no-repeat center center;
+            background-size: cover;
+            opacity: 0.5;
+            z-index: -1;
+        }
+        h1.title {
+            color: white;
+            text-align: center;
+            text-decoration: underline;
+            font-size: 48px;
+        }
+        nav {
+            text-align: center;
+            margin-top: 10px;
+            background: rgba(0,0,0,0.6);
+            padding: 10px 0;
+        }
+        nav a {
+            margin: 0 15px;
+            color: white;
+            text-decoration: none;
+            border: 1px solid white;
+            padding: 8px 15px;
+            border-radius: 4px;
+            background: rgba(0,0,0,0.6);
+        }
+        #mlContainer {
+            background: rgba(0,0,0,0.6);
+            color: white;
+            padding: 20px;
+            margin: 20px auto;
+            width: 90%;
+            max-width: 1000px;
+            border-radius: 8px;
+        }
+        label { display:block; margin:5px 0; }
+        input, select { width:200px; }
+        #result { margin-top:20px; }
+        canvas { max-width:400px; margin:20px auto; display:block; }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1 class="title">Lennon Mueller</h1>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="app-development.html">App Development</a>
+        <a href="ai-ml.html">AI/ML</a>
+    </nav>
+    <div id="mlContainer">
+        <form id="churnForm">
+            <label>Gender
+                <select name="gender" id="gender">
+                    <option value="Male">Male</option>
+                    <option value="Female">Female</option>
+                </select>
+            </label>
+            <label>Senior Citizen
+                <select name="SeniorCitizen" id="SeniorCitizen">
+                    <option value="0">No</option>
+                    <option value="1">Yes</option>
+                </select>
+            </label>
+            <label>Partner
+                <select name="Partner" id="Partner">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                </select>
+            </label>
+            <label>Dependents
+                <select name="Dependents" id="Dependents">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                </select>
+            </label>
+            <label>Tenure <input type="number" name="tenure" id="tenure" value="1" min="0"></label>
+            <label>Phone Service
+                <select name="PhoneService" id="PhoneService">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                </select>
+            </label>
+            <label>Multiple Lines
+                <select name="MultipleLines" id="MultipleLines">
+                    <option value="No">No</option>
+                    <option value="Yes">Yes</option>
+                    <option value="No phone service">No phone service</option>
+                </select>
+            </label>
+            <label>Internet Service
+                <select name="InternetService" id="InternetService">
+                    <option value="DSL">DSL</option>
+                    <option value="Fiber optic">Fiber optic</option>
+                    <option value="No">No</option>
+                </select>
+            </label>
+            <label>Online Security
+                <select name="OnlineSecurity" id="OnlineSecurity">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Online Backup
+                <select name="OnlineBackup" id="OnlineBackup">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Device Protection
+                <select name="DeviceProtection" id="DeviceProtection">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Tech Support
+                <select name="TechSupport" id="TechSupport">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Streaming TV
+                <select name="StreamingTV" id="StreamingTV">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Streaming Movies
+                <select name="StreamingMovies" id="StreamingMovies">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                    <option value="No internet service">No internet service</option>
+                </select>
+            </label>
+            <label>Contract
+                <select name="Contract" id="Contract">
+                    <option value="Month-to-month">Month-to-month</option>
+                    <option value="One year">One year</option>
+                    <option value="Two year">Two year</option>
+                </select>
+            </label>
+            <label>Paperless Billing
+                <select name="PaperlessBilling" id="PaperlessBilling">
+                    <option value="Yes">Yes</option>
+                    <option value="No">No</option>
+                </select>
+            </label>
+            <label>Payment Method
+                <select name="PaymentMethod" id="PaymentMethod">
+                    <option value="Electronic check">Electronic check</option>
+                    <option value="Mailed check">Mailed check</option>
+                    <option value="Bank transfer (automatic)">Bank transfer (automatic)</option>
+                    <option value="Credit card (automatic)">Credit card (automatic)</option>
+                </select>
+            </label>
+            <label>Monthly Charges <input type="number" step="0.1" name="MonthlyCharges" id="MonthlyCharges" value="0"></label>
+            <label>Total Charges <input type="number" step="0.1" name="TotalCharges" id="TotalCharges" value="0"></label>
+            <button type="submit">Predict Churn</button>
+        </form>
+        <div id="result"></div>
+        <canvas id="contribChart"></canvas>
+    </div>
+<script>
+document.getElementById('churnForm').addEventListener('submit', async function(e){
+    e.preventDefault();
+    const form = e.target;
+    const data = {};
+    new FormData(form).forEach((v,k)=>data[k]=v);
+    const response = await fetch('http://localhost:8000/predict', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    });
+    const res = await response.json();
+    document.getElementById('result').innerText = 'Churn Probability: ' + (res.probability*100).toFixed(2) + '%';
+    const ctx = document.getElementById('contribChart').getContext('2d');
+    const labels = Object.keys(res.contributions);
+    const values = Object.values(res.contributions);
+    new Chart(ctx, {
+        type:'bar',
+        data:{ labels: labels, datasets:[{label:'SHAP', data:values, backgroundColor:'blue'}]},
+        options:{ scales:{ y:{ beginAtZero:true } } }
+    });
+});
+</script>
+</body>
+</html>

--- a/app-development.html
+++ b/app-development.html
@@ -83,6 +83,7 @@
     <nav>
         <a href="index.html">Home</a>
         <a href="app-development.html">App Development</a>
+        <a href="ai-ml.html">AI/ML</a>
     </nav>
 <div id="appContainer">
     <div id="controls">

--- a/index.html
+++ b/index.html
@@ -58,9 +58,10 @@
     <nav>
         <a href="index.html">Home</a>
         <a href="app-development.html">App Development</a>
+        <a href="ai-ml.html">AI/ML</a>
     </nav>
     <div id="homeContainer">
-        <p>Welcome to my portfolio. Check out the App Development tab to see my projects.</p>
+        <p>Welcome to my portfolio. Check out the App Development and AI/ML tabs to see my projects.</p>
     </div>
 </body>
 </html>

--- a/ml/api.py
+++ b/ml/api.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+import pandas as pd
+import numpy as np
+import joblib
+from tensorflow import keras
+import shap
+import json
+
+app = FastAPI()
+
+model = keras.models.load_model('churn_model.h5')
+preprocess = joblib.load('preprocess.pkl')
+try:
+    with open('metrics.json') as f:
+        metrics_info = json.load(f)
+except FileNotFoundError:
+    metrics_info = {}
+
+# SHAP explainer with simple background
+dummy = np.zeros((1, model.input_shape[1]))
+explainer = shap.KernelExplainer(model.predict, dummy)
+
+@app.post('/predict')
+def predict(features: dict):
+    df = pd.DataFrame([features])
+    processed = preprocess.transform(df)
+    prob = float(model.predict(processed)[0][0])
+    shap_vals = explainer.shap_values(processed)[0]
+    names = preprocess.get_feature_names_out()
+    top_idx = np.argsort(np.abs(shap_vals))[::-1][:5]
+    contributions = {names[i]: float(shap_vals[i]) for i in top_idx}
+    return {'probability': prob, 'contributions': contributions}
+
+@app.get('/metrics')
+def metrics():
+    return metrics_info

--- a/ml/train_churn_model.py
+++ b/ml/train_churn_model.py
@@ -1,0 +1,100 @@
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+from tensorflow import keras
+import joblib
+import json
+from datetime import datetime
+
+# Load dataset
+DATA_FILE = '../WA_Fn-UseC_-Telco-Customer-Churn.csv'
+
+data = pd.read_csv(DATA_FILE)
+
+# Preprocess
+data['TotalCharges'] = pd.to_numeric(data['TotalCharges'], errors='coerce')
+# Drop customerID
+if 'customerID' in data.columns:
+    data = data.drop('customerID', axis=1)
+# Drop rows with missing target
+data = data.dropna(subset=['Churn'])
+
+X = data.drop('Churn', axis=1)
+y = data['Churn'].map({'Yes': 1, 'No': 0})
+
+numeric_features = X.select_dtypes(include=['int64', 'float64']).columns
+text_features = X.select_dtypes(include=['object']).columns
+
+numeric_transformer = Pipeline([
+    ('imputer', SimpleImputer(strategy='median')),
+    ('scaler', StandardScaler())
+])
+
+categorical_transformer = Pipeline([
+    ('imputer', SimpleImputer(strategy='most_frequent')),
+    ('onehot', OneHotEncoder(handle_unknown='ignore'))
+])
+
+preprocess = ColumnTransformer([
+    ('num', numeric_transformer, numeric_features),
+    ('cat', categorical_transformer, text_features)
+])
+
+X_processed = preprocess.fit_transform(X)
+
+# Train/val/test split
+X_train, X_temp, y_train, y_temp = train_test_split(
+    X_processed, y, test_size=0.4, stratify=y, random_state=42)
+X_val, X_test, y_val, y_test = train_test_split(
+    X_temp, y_temp, test_size=0.5, stratify=y_temp, random_state=42)
+
+input_dim = X_train.shape[1]
+model = keras.models.Sequential([
+    keras.layers.Input(shape=(input_dim,)),
+    keras.layers.Dense(64, activation='relu'),
+    keras.layers.BatchNormalization(),
+    keras.layers.Dropout(0.3),
+    keras.layers.Dense(32, activation='relu'),
+    keras.layers.BatchNormalization(),
+    keras.layers.Dropout(0.3),
+    keras.layers.Dense(16, activation='relu'),
+    keras.layers.BatchNormalization(),
+    keras.layers.Dropout(0.3),
+    keras.layers.Dense(1, activation='sigmoid')
+])
+
+model.compile(
+    optimizer=keras.optimizers.Adam(3e-4),
+    loss='binary_crossentropy',
+    metrics=[keras.metrics.AUC(name='auc'),
+             keras.metrics.Precision(name='precision'),
+             keras.metrics.Recall(name='recall')]
+)
+
+early_stop = keras.callbacks.EarlyStopping(
+    monitor='val_loss', patience=10, restore_best_weights=True)
+
+history = model.fit(
+    X_train.toarray(), y_train,
+    validation_data=(X_val.toarray(), y_val),
+    epochs=100, batch_size=32,
+    callbacks=[early_stop]
+)
+
+metrics = model.evaluate(X_test.toarray(), y_test, verbose=0)
+metrics_dict = {
+    'auc': float(metrics[1]),
+    'precision': float(metrics[2]),
+    'recall': float(metrics[3]),
+    'trained_at': datetime.utcnow().isoformat()
+}
+
+with open('metrics.json', 'w') as f:
+    json.dump(metrics_dict, f)
+
+joblib.dump(preprocess, 'preprocess.pkl')
+model.save('churn_model.h5')


### PR DESCRIPTION
## Summary
- add new AI/ML page with churn prediction form
- link AI/ML tab from existing pages
- scaffold churn model training pipeline with sklearn and keras
- add FastAPI service for predictions and metrics

## Testing
- `python -m py_compile ml/train_churn_model.py ml/api.py`
- `python ml/train_churn_model.py` *(fails: No module named 'pandas')*
- `python ml/api.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685438376b30832b9634fe070d736ff2