### PR TITLE
Add churn dashboard

### DIFF
--- a/ai-ml.html
+++ b/ai-ml.html
@@ -65,144 +65,33 @@
         <a href="ai-ml.html">AI/ML</a>
     </nav>
     <div id="mlContainer">
-        <form id="churnForm">
-            <label>Gender
-                <select name="gender" id="gender">
-                    <option value="Male">Male</option>
-                    <option value="Female">Female</option>
-                </select>
-            </label>
-            <label>Senior Citizen
-                <select name="SeniorCitizen" id="SeniorCitizen">
-                    <option value="0">No</option>
-                    <option value="1">Yes</option>
-                </select>
-            </label>
-            <label>Partner
-                <select name="Partner" id="Partner">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                </select>
-            </label>
-            <label>Dependents
-                <select name="Dependents" id="Dependents">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                </select>
-            </label>
-            <label>Tenure <input type="number" name="tenure" id="tenure" value="1" min="0"></label>
-            <label>Phone Service
-                <select name="PhoneService" id="PhoneService">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                </select>
-            </label>
-            <label>Multiple Lines
-                <select name="MultipleLines" id="MultipleLines">
-                    <option value="No">No</option>
-                    <option value="Yes">Yes</option>
-                    <option value="No phone service">No phone service</option>
-                </select>
-            </label>
-            <label>Internet Service
-                <select name="InternetService" id="InternetService">
-                    <option value="DSL">DSL</option>
-                    <option value="Fiber optic">Fiber optic</option>
-                    <option value="No">No</option>
-                </select>
-            </label>
-            <label>Online Security
-                <select name="OnlineSecurity" id="OnlineSecurity">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Online Backup
-                <select name="OnlineBackup" id="OnlineBackup">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Device Protection
-                <select name="DeviceProtection" id="DeviceProtection">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Tech Support
-                <select name="TechSupport" id="TechSupport">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Streaming TV
-                <select name="StreamingTV" id="StreamingTV">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Streaming Movies
-                <select name="StreamingMovies" id="StreamingMovies">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                    <option value="No internet service">No internet service</option>
-                </select>
-            </label>
-            <label>Contract
-                <select name="Contract" id="Contract">
-                    <option value="Month-to-month">Month-to-month</option>
-                    <option value="One year">One year</option>
-                    <option value="Two year">Two year</option>
-                </select>
-            </label>
-            <label>Paperless Billing
-                <select name="PaperlessBilling" id="PaperlessBilling">
-                    <option value="Yes">Yes</option>
-                    <option value="No">No</option>
-                </select>
-            </label>
-            <label>Payment Method
-                <select name="PaymentMethod" id="PaymentMethod">
-                    <option value="Electronic check">Electronic check</option>
-                    <option value="Mailed check">Mailed check</option>
-                    <option value="Bank transfer (automatic)">Bank transfer (automatic)</option>
-                    <option value="Credit card (automatic)">Credit card (automatic)</option>
-                </select>
-            </label>
-            <label>Monthly Charges <input type="number" step="0.1" name="MonthlyCharges" id="MonthlyCharges" value="0"></label>
-            <label>Total Charges <input type="number" step="0.1" name="TotalCharges" id="TotalCharges" value="0"></label>
-            <button type="submit">Predict Churn</button>
-        </form>
-        <div id="result"></div>
-        <canvas id="contribChart"></canvas>
+        <h2>Customer Churn Dashboard</h2>
+        <p id="summary"></p>
+        <div id="metrics"></div>
+        <canvas id="topCombosChart"></canvas>
+        <canvas id="lowCombosChart"></canvas>
     </div>
 <script>
-document.getElementById('churnForm').addEventListener('submit', async function(e){
-    e.preventDefault();
-    const form = e.target;
-    const data = {};
-    new FormData(form).forEach((v,k)=>data[k]=v);
-    const response = await fetch('http://localhost:5000/predict', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(data)
-    });
-    const res = await response.json();
-    document.getElementById('result').innerText = 'Churn Probability: ' + (res.probability*100).toFixed(2) + '%';
-    const ctx = document.getElementById('contribChart').getContext('2d');
-    const labels = Object.keys(res.contributions);
-    const values = Object.values(res.contributions);
-    new Chart(ctx, {
-        type:'bar',
-        data:{ labels: labels, datasets:[{label:'SHAP', data:values, backgroundColor:'blue'}]},
-        options:{ scales:{ y:{ beginAtZero:true } } }
-    });
-});
+async function loadDashboard(){
+    const res = await fetch('http://localhost:5000/dashboard');
+    const data = await res.json();
+    document.getElementById('summary').innerText =
+        `Dataset: ${data.total_customers} customers, Churn Rate: ${(data.churn_rate*100).toFixed(1)}%`;
+    const m = data.metrics;
+    document.getElementById('metrics').innerText =
+        `Model AUC: ${m.auc.toFixed(3)} | Precision: ${m.precision.toFixed(3)} | Recall: ${m.recall.toFixed(3)}`;
+
+    const topCtx = document.getElementById('topCombosChart').getContext('2d');
+    const topLabels = data.top_combos.map(c=>`${c.features[0]}=${c.values[0]}\n${c.features[1]}=${c.values[1]}`);
+    const topRates = data.top_combos.map(c=>c.rate*100);
+    new Chart(topCtx,{type:'bar',data:{labels:topLabels,datasets:[{label:'Churn %',data:topRates,backgroundColor:'red'}]},options:{scales:{y:{beginAtZero:true,max:100}}}});
+
+    const lowCtx = document.getElementById('lowCombosChart').getContext('2d');
+    const lowLabels = data.bottom_combos.map(c=>`${c.features[0]}=${c.values[0]}\n${c.features[1]}=${c.values[1]}`);
+    const lowRates = data.bottom_combos.map(c=>c.rate*100);
+    new Chart(lowCtx,{type:'bar',data:{labels:lowLabels,datasets:[{label:'Churn %',data:lowRates,backgroundColor:'green'}]},options:{scales:{y:{beginAtZero:true,max:100}}}});
+}
+loadDashboard();
 </script>
 </body>
 </html>

--- a/ml/api.py
+++ b/ml/api.py
@@ -15,6 +15,11 @@ try:
         metrics_info = json.load(f)
 except FileNotFoundError:
     metrics_info = {}
+try:
+    with open('combos.json') as f:
+        combos_info = json.load(f)
+except FileNotFoundError:
+    combos_info = {}
 
 # SHAP explainer with simple background
 dummy = np.zeros((1, model.input_shape[1]))
@@ -34,3 +39,14 @@ def predict(features: dict):
 @app.get('/metrics')
 def metrics():
     return metrics_info
+
+
+@app.get('/dashboard')
+def dashboard_data():
+    return {
+        'metrics': metrics_info,
+        'top_combos': combos_info.get('top_combos', []),
+        'bottom_combos': combos_info.get('bottom_combos', []),
+        'total_customers': combos_info.get('total_customers'),
+        'churn_rate': combos_info.get('churn_rate')
+    }

--- a/ml/train_dashboard_model.py
+++ b/ml/train_dashboard_model.py
@@ -1,0 +1,133 @@
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+from tensorflow import keras
+import json
+from datetime import datetime
+
+DATA_FILE = '../WA_Fn-UseC_-Telco-Customer-Churn.csv'
+
+# Load dataset
+data = pd.read_csv(DATA_FILE)
+
+# Basic cleaning
+data['TotalCharges'] = pd.to_numeric(data['TotalCharges'], errors='coerce')
+if 'customerID' in data.columns:
+    data = data.drop('customerID', axis=1)
+
+data = data.dropna(subset=['Churn'])
+
+X = data.drop('Churn', axis=1)
+y = data['Churn'].map({'Yes': 1, 'No': 0})
+
+numeric_features = X.select_dtypes(include=['int64', 'float64']).columns
+categorical_features = X.select_dtypes(include=['object']).columns
+
+numeric_transformer = Pipeline([
+    ('imputer', SimpleImputer(strategy='median')),
+    ('scaler', StandardScaler())
+])
+
+categorical_transformer = Pipeline([
+    ('imputer', SimpleImputer(strategy='most_frequent')),
+    ('onehot', OneHotEncoder(handle_unknown='ignore'))
+])
+
+preprocess = ColumnTransformer([
+    ('num', numeric_transformer, numeric_features),
+    ('cat', categorical_transformer, categorical_features)
+])
+
+X_processed = preprocess.fit_transform(X)
+
+# Split data
+X_train, X_temp, y_train, y_temp = train_test_split(
+    X_processed, y, test_size=0.4, stratify=y, random_state=42)
+X_val, X_test, y_val, y_test = train_test_split(
+    X_temp, y_temp, test_size=0.5, stratify=y_temp, random_state=42)
+
+# Build neural network
+input_dim = X_train.shape[1]
+model = keras.models.Sequential([
+    keras.layers.Input(shape=(input_dim,)),
+    keras.layers.Dense(64, activation='relu'),
+    keras.layers.Dropout(0.3),
+    keras.layers.Dense(32, activation='relu'),
+    keras.layers.Dropout(0.3),
+    keras.layers.Dense(1, activation='sigmoid')
+])
+
+model.compile(
+    optimizer=keras.optimizers.Adam(3e-4),
+    loss='binary_crossentropy',
+    metrics=[keras.metrics.AUC(name='auc'),
+             keras.metrics.Precision(name='precision'),
+             keras.metrics.Recall(name='recall')]
+)
+
+early_stop = keras.callbacks.EarlyStopping(
+    monitor='val_loss', patience=10, restore_best_weights=True)
+
+model.fit(
+    X_train.toarray(), y_train,
+    validation_data=(X_val.toarray(), y_val),
+    epochs=100, batch_size=32,
+    callbacks=[early_stop], verbose=0
+)
+
+metrics = model.evaluate(X_test.toarray(), y_test, verbose=0)
+metrics_dict = {
+    'auc': float(metrics[1]),
+    'precision': float(metrics[2]),
+    'recall': float(metrics[3]),
+    'trained_at': datetime.utcnow().isoformat()
+}
+
+# Save model and preprocess objects
+model.save('churn_model.h5')
+import joblib
+joblib.dump(preprocess, 'preprocess.pkl')
+
+# Feature combination analysis
+comb_data = data.copy()
+comb_data['tenure_bin'] = pd.cut(comb_data['tenure'], bins=[0,12,24,48,72], labels=['0-12','12-24','24-48','48+'])
+comb_data['charges_bin'] = pd.cut(comb_data['MonthlyCharges'], bins=[0,35,70,120], labels=['<35','35-70','70+'])
+
+pairs = [
+    ('Contract','TechSupport'),
+    ('InternetService','PaymentMethod'),
+    ('tenure_bin','charges_bin')
+]
+
+combo_records = []
+for f1, f2 in pairs:
+    g = comb_data.groupby([f1, f2])['Churn'].agg(['mean','count']).reset_index()
+    g = g[g['count'] >= 20]
+    for _, row in g.iterrows():
+        combo_records.append({
+            'features': [f1, f2],
+            'values': [row[f1], row[f2]],
+            'rate': float(row['mean']),
+            'count': int(row['count'])
+        })
+
+combo_records = sorted(combo_records, key=lambda x: x['rate'])
+lowest = combo_records[:5]
+highest = combo_records[-5:][::-1]
+
+combo_info = {
+    'top_combos': highest,
+    'bottom_combos': lowest,
+    'total_customers': int(len(comb_data)),
+    'churn_rate': float(y.mean())
+}
+
+with open('metrics.json', 'w') as f:
+    json.dump(metrics_dict, f)
+
+with open('combos.json', 'w') as f:
+    json.dump(combo_info, f)


### PR DESCRIPTION
## Summary
- implement training script that produces churn model and combination analysis
- update API with `/dashboard` endpoint returning combo stats
- redesign AI/ML page into a storytelling dashboard showing churn rates, top and bottom combos, and model metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python ml/train_dashboard_model.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68544a5e18b0832bbef84c1dc3a3c6db