### PR TITLE
Fix label overlap on AI/ML charts

### DIFF
--- a/ai-ml.html
+++ b/ai-ml.html
@@ -56,7 +56,7 @@
         canvas {
             width: 100%;
             max-width: 800px;
-            margin: 20px auto;
+            margin: 70px auto;
             display: block;
         }
         #summary, #metrics {
@@ -101,7 +101,7 @@ async function loadDashboard(){
         options:{
             scales:{
                 y:{beginAtZero:true,max:100},
-                x:{ticks:{maxRotation:0,minRotation:0,autoSkip:false}}
+                x:{ticks:{maxRotation:45,minRotation:45,autoSkip:false}}
             }
         }
     });
@@ -118,7 +118,7 @@ async function loadDashboard(){
         options:{
             scales:{
                 y:{beginAtZero:true,max:100},
-                x:{ticks:{maxRotation:0,minRotation:0,autoSkip:false}}
+                x:{ticks:{maxRotation:45,minRotation:45,autoSkip:false}}
             }
         }
     });


### PR DESCRIPTION
## Summary
- rotate x‑axis labels on the churn charts for readability
- add extra margin under each chart

## Testing
- `python -m py_compile main.py ml/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854879f3014832b99d72a1079a92904