### PR TITLE
Add churn analysis script and dashboard update

### DIFF
--- a/ai-ml.html
+++ b/ai-ml.html
@@ -59,7 +59,7 @@
             margin: 70px auto;
             display: block;
         }
-        #summary, #metrics {
+        #summary, #highestRule {
             margin: 10px 0;
         }
     </style>
@@ -75,7 +75,7 @@
     <div id="mlContainer">
         <h2>Customer Churn Dashboard</h2>
         <p id="summary"></p>
-        <p id="metrics"></p>
+        <p id="highestRule"></p>
         <canvas id="topCombosChart"></canvas>
         <canvas id="lowCombosChart"></canvas>
     </div>
@@ -85,9 +85,7 @@ async function loadDashboard(){
     const data = await res.json();
     document.getElementById('summary').innerText =
         `Dataset: ${data.total_customers} customers, Churn Rate: ${(data.churn_rate*100).toFixed(1)}%`;
-    const m = data.metrics;
-    document.getElementById('metrics').innerText =
-        `Model AUC: ${m.auc.toFixed(3)} | Precision: ${m.precision.toFixed(3)} | Recall: ${m.recall.toFixed(3)}`;
+    document.getElementById('highestRule').innerText = data.highest_rule;
 
     const topCtx = document.getElementById('topCombosChart').getContext('2d');
     const topLabels = data.top_combos.map(c=>`${c.features[0]}=${c.values[0]}\n${c.features[1]}=${c.values[1]}`);

--- a/combos.json
+++ b/combos.json
@@ -124,5 +124,6 @@
     }
   ],
   "total_customers": 7043,
-  "churn_rate": 0.2653698707936959
+  "churn_rate": 0.2653698707936959,
+  "highest_rule": "Customers with tenure_bin = 0-12 and charges_bin = 70+ churn at 68.8% (n=831)."
 }

--- a/main.py
+++ b/main.py
@@ -80,11 +80,11 @@ async def get_metrics():
 async def dashboard_data():
     """Return data used by the churn dashboard."""
     return {
-        "metrics": metrics_info,
         "top_combos": combos_info.get("top_combos", []),
         "bottom_combos": combos_info.get("bottom_combos", []),
         "total_customers": combos_info.get("total_customers"),
         "churn_rate": combos_info.get("churn_rate"),
+        "highest_rule": combos_info.get("highest_rule"),
     }
 
 

--- a/ml/describe_churn.py
+++ b/ml/describe_churn.py
@@ -1,0 +1,85 @@
+import csv
+from collections import defaultdict
+import json
+
+DATA_FILE = '../WA_Fn-UseC_-Telco-Customer-Churn.csv'
+
+# Load rows
+rows = []
+with open(DATA_FILE, newline='') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        if not row.get('Churn'):
+            continue
+        row['MonthlyCharges'] = float(row['MonthlyCharges']) if row['MonthlyCharges'] else None
+        row['tenure'] = int(row['tenure']) if row['tenure'] else None
+        rows.append(row)
+
+def tenure_bin(val):
+    if val is None:
+        return None
+    if val < 12:
+        return '0-12'
+    if val < 24:
+        return '12-24'
+    if val < 48:
+        return '24-48'
+    return '48+'
+
+def charges_bin(val):
+    if val is None:
+        return None
+    if val < 35:
+        return '<35'
+    if val < 70:
+        return '35-70'
+    return '70+'
+
+for row in rows:
+    row['tenure_bin'] = tenure_bin(row['tenure'])
+    row['charges_bin'] = charges_bin(row['MonthlyCharges'])
+
+pairs = [
+    ('Contract','TechSupport'),
+    ('InternetService','PaymentMethod'),
+    ('tenure_bin','charges_bin')
+]
+
+records = []
+for f1, f2 in pairs:
+    agg = defaultdict(lambda: [0,0])
+    for row in rows:
+        a,b = row.get(f1), row.get(f2)
+        if not a or not b:
+            continue
+        key = (a,b)
+        churn = 1 if row['Churn'] == 'Yes' else 0
+        agg[key][0] += churn
+        agg[key][1] += 1
+    for (a,b),(s,c) in agg.items():
+        if c >= 20:
+            records.append({'features':[f1,f2],'values':[a,b],'rate':s/c,'count':c})
+
+records.sort(key=lambda x: x['rate'])
+lowest = records[:5]
+highest = records[-5:][::-1]
+
+# Build a story from the highest combo
+best = highest[0]
+f1,f2 = best['features']
+v1,v2 = best['values']
+story = (
+    f"Customers with {f1} = {v1} and {f2} = {v2} churn at "
+    f"{best['rate']*100:.1f}% (n={best['count']})."
+)
+
+result = {
+    'top_combos': highest,
+    'bottom_combos': lowest,
+    'total_customers': len(rows),
+    'churn_rate': sum(1 for r in rows if r['Churn']=='Yes')/len(rows),
+    'highest_rule': story
+}
+
+with open('../combos.json','w') as f:
+    json.dump(result,f,indent=2)


### PR DESCRIPTION
## Summary
- compute churn statistics via new `ml/describe_churn.py`
- update server API to expose `highest_rule` from descriptive stats
- display highest churn rule on the AI/ML dashboard instead of model metrics
- refresh `combos.json` with a textual rule explanation

## Testing
- `python ml/describe_churn.py`
- `python -m uvicorn main:app --port 5000 --reload` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6854b2dbb798832b8014d8d7ea06a289