### PR TITLE
Align backtest with Streamlit logic

### DIFF
--- a/app-development.html
+++ b/app-development.html
@@ -61,12 +61,6 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const FILE_PATH = 'Updated_Dataset_with_Signals_Ranked.csv';
-    const INITIAL_INVEST = 50000;
-    const CONTRIB_AMOUNT = 3000;
-    const CONTRIB_FREQ = 22;
-    const HOLD_DAYS = 25;
-    const MANUAL_EXIT_DATE = '6/27/2024';
-    const RESUME_DATE = '6/20/2025';
     const CALC_RESET_DATE = '6/20/2025';
 
     let dataset = [];
@@ -78,9 +72,10 @@ document.addEventListener('DOMContentLoaded', function() {
     let roi = 0;
     let winRate = 0;
 
-    fetch(FILE_PATH)
-        .then(r => r.text())
-        .then(text => { parseDataset(text); runBacktest(); populateUI(); });
+    Promise.all([
+        fetch(FILE_PATH).then(r => r.text()),
+        fetch('/backtest').then(r => r.json())
+    ]).then(([text, bt]) => { parseDataset(text); processBacktest(bt); populateUI(); });
 
     function parseDataset(text){
         const lines = text.trim().split('\n');
@@ -104,97 +99,14 @@ document.addEventListener('DOMContentLoaded', function() {
         dateIndex = [...new Set(dataset.map(r=>r.date))];
     }
 
-    function runBacktest(){
-        let cash = INITIAL_INVEST;
-        let contribCtr = 0;
-        const portfolio = [];
-        const trades = [];
-        let tradingActive = true;
-        equityCurve = [];
-        tradeHistory = [];
 
-        for(let i=0;i<dateIndex.length;i++){
-            const currDate = dateIndex[i];
-            contribCtr++;
-            if(contribCtr===CONTRIB_FREQ){ cash += CONTRIB_AMOUNT; contribCtr=0; }
-
-            if(new Date(currDate).getTime() === new Date(MANUAL_EXIT_DATE).getTime()){
-                for(const pos of [...portfolio]){
-                    const row = dataset.find(r => r.company===pos.company && r.date===currDate);
-                    if(!row) continue;
-                    const px = row.price;
-                    const profit = (px-pos.buy_price)*pos.shares;
-                    cash += pos.shares*px;
-                    trades.push(profit>0);
-                    tradeHistory.push({company:pos.company,date:currDate,action:'sell',price:px});
-                }
-                portfolio.length = 0;
-                tradingActive = false;
-            }
-
-            if(new Date(currDate).getTime() >= new Date(RESUME_DATE).getTime()){
-                tradingActive = true;
-            }
-
-            const dailyRows = dataset.filter(r=>r.date===currDate);
-            for(const row of dailyRows){
-                if(tradingActive && row.buy===1 && cash>0 && i+1<dateIndex.length){
-                    const nxt = dataset.find(r=>r.company===row.company && r.date===dateIndex[i+1]);
-                    if(!nxt) continue;
-                    const qty = (cash*0.30)/nxt.open;
-                    if(qty>=1){
-                        const invest = qty*nxt.open;
-                        cash -= invest;
-                        const buyDate = dateIndex[i+1];
-                        const sellDate = (i+HOLD_DAYS < dateIndex.length) ? dateIndex[i+HOLD_DAYS] : null;
-                        portfolio.push({company:row.company,buy_date:buyDate,sell_date:sellDate,shares:qty,buy_price:nxt.open});
-                        tradeHistory.push({company:row.company,date:buyDate,action:'buy',price:nxt.open});
-                    }
-                }
-            }
-
-            for(let j=portfolio.length-1;j>=0;j--){
-                const pos = portfolio[j];
-                if(pos.sell_date && currDate===pos.sell_date){
-                    const row = dataset.find(r=>r.company===pos.company && r.date===pos.sell_date);
-                    if(!row) continue;
-                    const px = row.price;
-                    const profit = (px-pos.buy_price)*pos.shares;
-                    cash += pos.shares*px;
-                    trades.push(profit>0);
-                    tradeHistory.push({company:pos.company,date:currDate,action:'sell',price:px});
-                    portfolio.splice(j,1);
-                }
-            }
-
-            let pv = 0;
-            for(const pos of portfolio){
-                const r = dataset.find(x=>x.company===pos.company && x.date===currDate);
-                if(r) pv += pos.shares*r.price;
-            }
-            equityCurve.push({date: currDate, value: cash + pv});
-        }
-
-        const totalContrib = INITIAL_INVEST + CONTRIB_AMOUNT * Math.floor(dateIndex.length/CONTRIB_FREQ);
-        finalVal = equityCurve[equityCurve.length-1].value;
-        roi = ((finalVal-totalContrib)/totalContrib)*100;
-        winRate = trades.length ? (trades.filter(t=>t).length/trades.length)*100 : 0;
-
-        const lastDate = dateIndex[dateIndex.length-1];
-        openPositions = portfolio.map(pos => {
-            const row = dataset.find(r=>r.company===pos.company && r.date===lastDate);
-            if(!row) return null;
-            let daysRemaining;
-            if(pos.sell_date){
-                daysRemaining = Math.floor((new Date(pos.sell_date) - new Date(lastDate))/(1000*60*60*24));
-            } else {
-                const held = Math.floor((new Date(lastDate)-new Date(pos.buy_date))/(1000*60*60*24));
-                daysRemaining = HOLD_DAYS - held;
-            }
-            const plVal = (row.price-pos.buy_price)*pos.shares;
-            const plPct = (row.price-pos.buy_price)/pos.buy_price*100;
-            return {company:pos.company,shares:pos.shares,buy_date:pos.buy_date,buy_price:pos.buy_price,current_price:row.price,pl_val:plVal,pl_pct:plPct,days_remaining:daysRemaining};
-        }).filter(Boolean);
+    function processBacktest(bt){
+        equityCurve = bt.equity_curve;
+        openPositions = bt.open_positions;
+        tradeHistory = bt.trades;
+        finalVal = bt.final_value;
+        roi = bt.roi;
+        winRate = bt.win_rate;
     }
 
     function populateUI(){

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from typing import Dict
 import json
 import os
+import pandas as pd
 
 app = FastAPI()
 
@@ -17,6 +18,147 @@ try:
         metrics_info = json.load(f)
 except FileNotFoundError:
     pass
+
+# ----- Backtest configuration -----
+FILE_PATH = "Updated_Dataset_with_Signals_Ranked.csv"
+INITIAL_INVEST = 50_000
+CONTRIB_AMOUNT = 3_000
+CONTRIB_FREQ = 22
+MANUAL_EXIT_DATE = pd.Timestamp("2024-06-27")
+HOLD_DAYS = 25
+
+def load_prices(fp: str) -> pd.DataFrame:
+    df = pd.read_csv(fp)
+    df["Date"] = pd.to_datetime(df["Date"])
+    for col in ["Price", "Open"]:
+        df[col] = pd.to_numeric(
+            df[col].astype(str).str.replace(r"[$,]", "", regex=True), errors="coerce"
+        )
+    return df.sort_values("Date")
+
+df_sorted = load_prices(os.path.join(base_dir, FILE_PATH))
+date_index = df_sorted["Date"].unique()
+
+
+def run_backtest(df: pd.DataFrame):
+    cash, contrib_ctr = INITIAL_INVEST, 0
+    portfolio, trades, equity_curve = [], [], []
+    trade_history = []
+
+    for i, curr_date in enumerate(date_index):
+        contrib_ctr += 1
+        if contrib_ctr == CONTRIB_FREQ:
+            cash += CONTRIB_AMOUNT
+            contrib_ctr = 0
+
+        if curr_date == MANUAL_EXIT_DATE:
+            for pos in portfolio[:]:
+                px = df.loc[(df["Company"] == pos["company"]) & (df["Date"] == curr_date), "Price"]
+                if px.empty:
+                    continue
+                px = px.iloc[0]
+                profit = (px - pos["buy_price"]) * pos["shares_bought"]
+                cash += pos["shares_bought"] * px
+                trades.append(profit > 0)
+                trade_history.append(
+                    dict(company=pos["company"], date=curr_date, action="sell", price=px)
+                )
+            portfolio.clear()
+
+        todays_rows = df[df["Date"] == curr_date]
+        for _, row in todays_rows.iterrows():
+            if row["30 Day Buy Signal"] == 1 and cash > 0 and i + 1 < len(date_index):
+                nxt = df[(df["Company"] == row["Company"]) & (df["Date"] == date_index[i + 1])]
+                if nxt.empty:
+                    continue
+                next_open = nxt.iloc[0]["Open"]
+                qty = (cash * 0.30) / next_open
+                if qty >= 1:
+                    invest = qty * next_open
+                    cash -= invest
+                    buy_date = date_index[i + 1]
+                    sell_date = date_index[i + HOLD_DAYS] if i + HOLD_DAYS < len(date_index) else None
+                    portfolio.append(
+                        dict(
+                            company=row["Company"],
+                            buy_date=buy_date,
+                            sell_date=sell_date,
+                            shares_bought=qty,
+                            buy_price=next_open,
+                        )
+                    )
+                    trade_history.append(
+                        dict(company=row["Company"], date=buy_date, action="buy", price=next_open)
+                    )
+
+        for pos in portfolio[:]:
+            if pos["sell_date"] is not None and curr_date == pos["sell_date"]:
+                px = df.loc[(df["Company"] == pos["company"]) & (df["Date"] == pos["sell_date"]), "Price"]
+                if px.empty:
+                    continue
+                px = px.iloc[0]
+                profit = (px - pos["buy_price"]) * pos["shares_bought"]
+                cash += pos["shares_bought"] * px
+                trades.append(profit > 0)
+                trade_history.append(
+                    dict(company=pos["company"], date=curr_date, action="sell", price=px)
+                )
+                portfolio.remove(pos)
+
+        pv = 0
+        for pos in portfolio:
+            cur_px = df.loc[(df["Company"] == pos["company"]) & (df["Date"] == curr_date), "Price"]
+            if not cur_px.empty:
+                pv += pos["shares_bought"] * cur_px.iloc[0]
+        equity_curve.append(cash + pv)
+
+    total_contrib = INITIAL_INVEST + CONTRIB_AMOUNT * (len(date_index) // CONTRIB_FREQ)
+    final_val = equity_curve[-1]
+    roi = (final_val - total_contrib) / total_contrib * 100
+    win_rate = (sum(trades) / len(trades) * 100) if trades else 0
+
+    last_date = date_index[-1]
+    rows = []
+    for pos in portfolio:
+        last_px = df.loc[(df["Company"] == pos["company"]) & (df["Date"] == last_date), "Price"]
+        if last_px.empty:
+            continue
+        last_px = last_px.iloc[0]
+        pl_val = (last_px - pos["buy_price"]) * pos["shares_bought"]
+        pl_pct = (last_px - pos["buy_price"]) / pos["buy_price"] * 100
+        if pos["sell_date"] is not None:
+            days_remaining = (pos["sell_date"] - last_date).days
+        else:
+            days_held = (last_date - pos["buy_date"]).days
+            days_remaining = HOLD_DAYS - days_held
+        rows.append(
+            {
+                "company": pos["company"],
+                "shares": round(pos["shares_bought"], 2),
+                "buy_date": pos["buy_date"].strftime("%-m/%-d/%Y"),
+                "buy_price": round(pos["buy_price"], 2),
+                "current_price": round(last_px, 2),
+                "pl_val": round(pl_val, 2),
+                "pl_pct": round(pl_pct, 2),
+                "days_remaining": days_remaining,
+            }
+        )
+    open_df = pd.DataFrame(rows)
+
+    trades_df = pd.DataFrame(trade_history)
+    return {
+        "equity_curve": [
+            {"date": d.strftime("%Y-%m-%d"), "value": v} for d, v in zip(date_index, equity_curve)
+        ],
+        "final_value": round(final_val, 2),
+        "roi": round(roi, 2),
+        "win_rate": round(win_rate, 2),
+        "open_positions": open_df.to_dict(orient="records"),
+        "trades": trades_df.to_dict(orient="records"),
+    }
+
+
+backtest_results = run_backtest(df_sorted)
 try:
     with open(os.path.join(base_dir, "combos.json")) as f:
         combos_info = json.load(f)
@@ -86,6 +228,12 @@ async def dashboard_data():
         "churn_rate": combos_info.get("churn_rate"),
         "highest_rule": combos_info.get("highest_rule"),
     }
+
+
+@app.get("/backtest")
+async def get_backtest():
+    """Return precomputed backtest results."""
+    return backtest_results
 
 
 # Serve the HTML and other static assets in the project directory


### PR DESCRIPTION
## Summary
- implement the Streamlit backtest algorithm in `main.py`
- expose `/backtest` API endpoint
- fetch precomputed backtest data in `app-development.html`
- remove old JS backtest logic

## Testing
- `python -m py_compile main.py ml/api.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5a74f838832bb73366ae68ed0e14