### PR TITLE
Convert portfolio to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Lennon Mueller Portfolio
+
+This repository contains a simple static portfolio site. The site is deployed using **GitHub Pages** through the workflow defined in `.github/workflows/static.yml`.
+
+To view the page after the workflow runs, visit the GitHub Pages URL for the repository.

--- a/ai-ml.html
+++ b/ai-ml.html
@@ -95,7 +95,7 @@
     </div>
 <script>
 async function loadDashboard(){
-    const res = await fetch('http://localhost:5000/dashboard');
+    const res = await fetch('combos.json');
     const data = await res.json();
     document.getElementById('summary').innerText =
         `Dataset: ${data.total_customers} customers, Churn Rate: ${(data.churn_rate*100).toFixed(1)}%`;

--- a/app-development.html
+++ b/app-development.html
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     Promise.all([
         fetch(FILE_PATH).then(r => r.text()),
-        fetch('/backtest').then(r => r.json())
+        fetch('backtest.json').then(r => r.json())
     ]).then(([text, bt]) => { parseDataset(text); processBacktest(bt); populateUI(); });
 
     function parseDataset(text){

--- a/backtest.json
+++ b/backtest.json
@@ -1,0 +1,11 @@
+{
+  "equity_curve": [
+    {"date": "2025-01-01", "value": 10000},
+    {"date": "2025-06-01", "value": 12000}
+  ],
+  "final_value": 12000,
+  "roi": 20.0,
+  "win_rate": 50.0,
+  "open_positions": [],
+  "trades": []
+}


### PR DESCRIPTION
## Summary
- fetch precomputed data from static files
- add example backtest JSON
- add README describing GitHub Pages deployment

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6888da9fba4c832ba56cd35a4158b2a9