### PR TITLE
docs: clarify typing banner and redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository contains a simple static portfolio site. The site is deployed using **GitHub Pages** through the workflow defined in `.github/workflows/static.yml`.
 
 To view the page after the workflow runs, visit the GitHub Pages URL for the repository.
+
+The home page includes a dynamic typing animation in the banner. If the page does not immediately show the updated banner, ensure the Pages workflow has completed successfully and refresh your browser.


### PR DESCRIPTION
## Summary
- document the new typing banner in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f0e1d090832b803f2a67ced12f61