### PR TITLE
Use environment variable for OpenAI key

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Insert OpenAI API key
+        run: sed -i "s|__OPENAI_API_KEY__|${OPENAI_API_KEY}|g" chatbot.js
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ This repository contains a simple static portfolio site. The site is deployed us
 To view the page after the workflow runs, visit the GitHub Pages URL for the repository.
 
 The home page includes a dynamic typing animation in the banner. If the page does not immediately show the updated banner, ensure the Pages workflow has completed successfully and refresh your browser.
+
+## Chatbot API Key
+
+The chatbot on the site now uses an OpenAI API key that is injected during the
+deployment workflow. Set the `OPENAI_API_KEY` secret in the repository so the
+workflow can substitute it into `chatbot.js` when deploying. The key will be
+baked into the static site, so ensure you are comfortable exposing it publicly.

--- a/ai-ml.html
+++ b/ai-ml.html
@@ -97,7 +97,6 @@
 
     <div id="chatbot">
         <div id="chatHeader">Ask about Lennon</div>
-        <input id="apiKey" type="text" placeholder="OpenAI API Key">
         <div id="chatMessages"></div>
         <div id="chatInputArea">
             <input id="chatInput" type="text" placeholder="Type a message">

--- a/chatbot.js
+++ b/chatbot.js
@@ -1,4 +1,6 @@
 const CV_TEXT = `PASTE LENNON CV TEXT HERE`;
+// OpenAI API key will be injected at build time by the workflow
+const OPENAI_API_KEY = '__OPENAI_API_KEY__';
 
 const chatMessages = [
   { role: 'system', content: `You are an enthusiastic assistant for Lennon's portfolio website. Use only the following CV information to answer questions. If you cannot answer based on the CV, say you don't know. CV: ${CV_TEXT}` },
@@ -14,14 +16,14 @@ function addMessage(sender, text) {
   container.scrollTop = container.scrollHeight;
 }
 
-function sendToOpenAI(apiKey, userText) {
+function sendToOpenAI(userText) {
   chatMessages.push({role:'user', content:userText});
   addMessage('user', userText);
   fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + apiKey
+      'Authorization': 'Bearer ' + OPENAI_API_KEY
     },
     body: JSON.stringify({model:'gpt-3.5-turbo', messages: chatMessages})
   })
@@ -40,20 +42,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const chatbox = document.getElementById('chatbot');
   const sendBtn = document.getElementById('sendBtn');
   const input = document.getElementById('chatInput');
-  const keyInput = document.getElementById('apiKey');
 
   addMessage('assistant', chatMessages[1].content);
 
   sendBtn.addEventListener('click', () => {
     const text = input.value.trim();
-    const key = keyInput.value.trim();
-    if (!key) {
-      alert('Please enter your OpenAI API key.');
-      return;
-    }
     if (text) {
       input.value = '';
-      sendToOpenAI(key, text);
+      sendToOpenAI(text);
     }
   });
 });

--- a/index.html
+++ b/index.html
@@ -81,7 +81,6 @@
 
     <div id="chatbot">
         <div id="chatHeader">Ask about Lennon</div>
-        <input id="apiKey" type="text" placeholder="OpenAI API Key">
         <div id="chatMessages"></div>
         <div id="chatInputArea">
             <input id="chatInput" type="text" placeholder="Type a message">


### PR DESCRIPTION
## Summary
- remove API key input box from pages
- load the key via constant in `chatbot.js`
- inject the secret during the Pages workflow
- document how to configure the secret

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688900be0c98832ba71a966b92c9209b