### PR TITLE
Fix deployment sed for OpenAI key

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Insert OpenAI API key
-        run: sed -i "s|__OPENAI_API_KEY__|${OPENAI_API_KEY}|g" chatbot.js
+        # Only replace the first placeholder occurrence so the runtime check
+        # for a missing key remains intact
+        run: sed -i "0,/__OPENAI_API_KEY__/s|__OPENAI_API_KEY__|${OPENAI_API_KEY}|" chatbot.js
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Setup Pages

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ The home page includes a dynamic typing animation in the banner. If the page doe
 
 The chatbot on the site now uses an OpenAI API key that is injected during the
 deployment workflow. Set the `OPENAI_API_KEY` secret in the repository so the
-workflow can substitute it into `chatbot.js` when deploying. The key will be
-baked into the static site, so ensure you are comfortable exposing it publicly.
+workflow can substitute it into `chatbot.js` when deploying. Only the first
+placeholder occurrence is replaced so the runtime check still detects a missing
+key. The key will be baked into the static site, so ensure you are comfortable
+exposing it publicly.


### PR DESCRIPTION
## Summary
- replace only the first `__OPENAI_API_KEY__` placeholder when deploying
- document placeholder behavior in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688961c69b98832b84309703c2f12a80