### PR TITLE
Clarify Pages workflow secret usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ deployment workflow. Set the `OPENAI_API_KEY` secret in the repository so the
 workflow can substitute it into `chatbot.js` when deploying. Only the first
 placeholder occurrence is replaced so the runtime check still detects a missing
 key. The key will be baked into the static site, so ensure you are comfortable
-exposing it publicly.
+exposing it publicly. **After adding the secret you must push a commit or
+manually run the Pages workflow** so this replacement step runs and your site
+includes the key.


### PR DESCRIPTION
## Summary
- clarify that a Pages workflow run is required after adding the `OPENAI_API_KEY` secret

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688964f3d9f0832b90d9bcdada9a7897