### PR TITLE
Fix chatbot function path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ only, so it never appears in the published JavaScript.
 
 Ensure the `OPENAI_API_KEY` secret is configured in the repository. When the
 Pages workflow runs, the key is made available to the function environment and
-the site can call `/api/chat` to interact with OpenAI.
+the site can call the `api/chat` endpoint (relative to the site root) to
+interact with OpenAI.

--- a/chatbot.js
+++ b/chatbot.js
@@ -35,7 +35,8 @@ December 2021-April 2022, H.O.P.E. Dashboard, Indiana Wesleyan University
 ▪ Risk algorithm was used to produce a risk history for every enrolled student. Risk history displays the daily evolution of a student’s risk score throughout their academic journey and has enabled the use of AI and machine-learning techniques to identify patterns of risk score behavior indicative of future withdrawal. 
 `;
 // Serverless function endpoint for OpenAI requests
-const API_URL = '/api/chat';
+// Use a relative path so the function works on GitHub Pages project sites
+const API_URL = 'api/chat';
 
 const chatMessages = [
   { role: 'system', content: `You are an enthusiastic assistant for Lennon's portfolio website. Use only the following CV information to answer questions. If you cannot answer based on the CV, say you don't know. CV: ${CV_TEXT}` },


### PR DESCRIPTION
## Summary
- use a relative path to call the Pages Function
- clarify README that `api/chat` is relative to the site root

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1c25560c832b9fa8ea862aa91fe3